### PR TITLE
First steps into sub-streams

### DIFF
--- a/data.proto
+++ b/data.proto
@@ -1,15 +1,15 @@
 message Payload {
-    required bytes data = 4;
+    repeated string tags = 2;
+    required bytes data = 1;
 }
 
 message Header {
     required uint64 time_id = 1;
     required uint64 offset = 2;
     required uint64 node_id = 3;
-    repeated string tags = 4;
 }
 
 message Data {
     required Header header = 1;
-    required Payload payload = 2;
+    repeated Payload payload = 2;
 }


### PR DESCRIPTION
This patch effectively does the following:
    - Changes input format to JSON (compatibility with others can be achieved, no effort was made in this direction)
    - Allows one to submit a multi-message, with single-message atomicity semantics, with arbitrary tags per sub-message
    - Allows easy implementation of multi-message addressing and sub-streaming, messages submitted as a unit being addressable as a unit (read: WINNING)
